### PR TITLE
CDAP-15830. Multiple file sink config validations.

### DIFF
--- a/src/main/java/io/cdap/plugin/mfs/EnumWithValue.java
+++ b/src/main/java/io/cdap/plugin/mfs/EnumWithValue.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.mfs;
+
+/**
+ * Enum which has string values as a part of it.
+ */
+public interface EnumWithValue {
+  String getValue();
+}

--- a/src/main/java/io/cdap/plugin/mfs/FilterType.java
+++ b/src/main/java/io/cdap/plugin/mfs/FilterType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mfs;
+
+public enum FilterType implements EnumWithValue {
+  NONE("None"),
+  EXPRESSION("Expression");
+
+  private final String value;
+
+  FilterType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return this.getValue();
+  }
+}

--- a/src/main/java/io/cdap/plugin/mfs/MultipleFileConfig.java
+++ b/src/main/java/io/cdap/plugin/mfs/MultipleFileConfig.java
@@ -1,15 +1,26 @@
 package io.cdap.plugin.mfs;
 
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.mfs.expression.EL;
+import io.cdap.plugin.mfs.expression.ELException;
 
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
  * Class description here.
  */
 public class MultipleFileConfig extends PluginConfig {
+  public static final String PROPERTY_OUTPUT_TYPE = "type";
+  public static final String PROPERTY_OUTPUT_FORMAT = "format";
+  public static final String PROPERTY_FILTERS = "filters";
+  public static final String PROPERTY_FILTERS_TYPE = "filtersType";
+
   @Name("prefix")
   @Macro
   private String prefix;
@@ -18,22 +29,22 @@ public class MultipleFileConfig extends PluginConfig {
   @Macro
   private String path;
 
-  @Name("type")
+  @Name(PROPERTY_OUTPUT_TYPE)
   @Macro
   @Nullable
   private String type;
 
-  @Name("format")
+  @Name(PROPERTY_OUTPUT_FORMAT)
   @Macro
   @Nullable
   private String format;
 
-  @Name("filters")
+  @Name(PROPERTY_FILTERS)
   @Macro
   @Nullable
   private String filters;
 
-  @Name("filters-type")
+  @Name(PROPERTY_FILTERS_TYPE)
   @Macro
   @Nullable
   private String filtersType;
@@ -47,6 +58,15 @@ public class MultipleFileConfig extends PluginConfig {
     this.filters = filters;
   }
 
+  private MultipleFileConfig(Builder builder) {
+    this.prefix = builder.prefix;
+    this.path = builder.path;
+    this.type = builder.type;
+    this.format = builder.format;
+    this.filtersType = builder.filtersType;
+    this.filters = builder.filters;
+  }
+
   public String getPrefix() {
     return prefix;
   }
@@ -55,25 +75,16 @@ public class MultipleFileConfig extends PluginConfig {
     return path;
   }
 
-  public String getType() {
-    if (type == null) {
-      return "Text";
-    }
-    return type;
+  public OutputType getType() {
+    return getEnumValueByString(OutputType.class, type, PROPERTY_OUTPUT_TYPE);
   }
 
-  public String getFormat() {
-    if (format == null) {
-      return "CSV";
-    }
-    return format;
+  public OutputFormat getFormat() {
+    return getEnumValueByString(OutputFormat.class, format, PROPERTY_OUTPUT_FORMAT);
   }
 
-  public String getFiltersType() {
-    if (filtersType == null) {
-      return "Expression";
-    }
-    return filtersType;
+  public FilterType getFiltersType() {
+    return getEnumValueByString(FilterType.class, filtersType, PROPERTY_FILTERS_TYPE);
   }
 
   public String[] getFiltersAsList() {
@@ -85,5 +96,134 @@ public class MultipleFileConfig extends PluginConfig {
       filters = "None";
     }
     return filters;
+  }
+
+  public void validate(FailureCollector failureCollector, Schema inputSchema) {
+    // trigger getters, so that they fail if value cannot be converted to enum.
+    try {
+      getType();
+    } catch (IllegalStateException ex) {
+      failureCollector.addFailure(ex.getMessage(), null)
+        .withConfigProperty(PROPERTY_OUTPUT_TYPE);
+    }
+
+    try {
+      getFormat();
+    } catch (IllegalStateException ex) {
+      failureCollector.addFailure(ex.getMessage(), null)
+        .withConfigProperty(PROPERTY_OUTPUT_FORMAT);
+    }
+
+    try {
+      getFiltersType();
+    } catch (IllegalStateException ex) {
+      failureCollector.addFailure(ex.getMessage(), null)
+        .withConfigProperty(PROPERTY_FILTERS_TYPE);
+      return; // if invalid filters type further validations does not make sense.
+    }
+
+    if (getFiltersType().equals(FilterType.EXPRESSION)) {
+      if (Strings.isNullOrEmpty(filters)) {
+        failureCollector.addFailure("Filter conditions must be set, when assigment type is \"Expression\"",
+                             null).withConfigProperty(PROPERTY_FILTERS);
+      } else {
+        EL el = new EL(new EL.DefaultFunctions());
+
+        for (String expression : getFiltersAsList()) {
+          try {
+            el.compile(expression);
+          } catch (ELException e) {
+            failureCollector.addFailure(String.format("Filter conditions contain an invalid expression. Reason: \"%s\"",
+                                               e.getMessage()), null)
+              .withConfigProperty(PROPERTY_FILTERS);
+          }
+
+          for (String variableName : el.variables()) {
+            if (inputSchema.getField(variableName) == null) {
+              failureCollector.addFailure(String.format(
+                "Filter conditions contain an invalid expression. Variable '%s' in not in the schema",
+                variableName), null)
+                .withConfigProperty(PROPERTY_FILTERS)
+                .withInputSchemaField(variableName);
+            }
+          }
+
+        }
+      }
+    } else {
+      if (!Strings.isNullOrEmpty(filters)) {
+        failureCollector.addFailure(String.format("Filter conditions must not be set, when assigment type is \"%s\"",
+                                           filtersType), null).withConfigProperty(PROPERTY_FILTERS);
+      }
+    }
+  }
+
+  public static <T extends EnumWithValue> T getEnumValueByString(Class<T> enumClass, String stringValue,
+                                                                 String propertyName) {
+    return Stream.of(enumClass.getEnumConstants())
+      .filter(keyType -> keyType.getValue().equalsIgnoreCase(stringValue))
+      .findAny()
+      .orElseThrow(() -> new IllegalStateException(
+        String.format("Unsupported value for '%s': '%s'", propertyName, stringValue)));
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static Builder builder(MultipleFileConfig copy) {
+    return new Builder()
+      .setPrefix(copy.getPrefix())
+      .setPath(copy.getPath())
+      .setType(copy.getType().toString())
+      .setFormat(copy.getFormat().toString())
+      .setFiltersType(copy.getFiltersType().toString())
+      .setFilters(copy.getFilters());
+  }
+
+  public static final class Builder {
+    private String prefix;
+    private String path;
+    private String type;
+    private String format;
+    private String filtersType;
+    private String filters;
+
+    private Builder() {
+    }
+
+    public Builder setPrefix(String prefix) {
+      this.prefix = prefix;
+      return this;
+    }
+
+    public Builder setPath(String path) {
+      this.path = path;
+      return this;
+    }
+
+    public Builder setType(String type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder setFormat(String format) {
+      this.format = format;
+      return this;
+    }
+
+    public Builder setFiltersType(String filtersType) {
+      this.filtersType = filtersType;
+      return this;
+    }
+
+    public Builder setFilters(String filters) {
+      this.filters = filters;
+      return this;
+    }
+
+    public MultipleFileConfig build() {
+      return new MultipleFileConfig(this);
+    }
   }
 }

--- a/src/main/java/io/cdap/plugin/mfs/MultipleFileSink.java
+++ b/src/main/java/io/cdap/plugin/mfs/MultipleFileSink.java
@@ -5,8 +5,11 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.batch.Output;
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.plugin.mfs.writer.MultipleFileOutputProvider;
@@ -22,6 +25,14 @@ public class MultipleFileSink extends BatchSink<StructuredRecord, NullWritable, 
   public static final String NAME = "MultipleFileSink";
   public static final String DESC = "Writes incoming records to multiple files.";
   private MultipleFileConfig config;
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
+    FailureCollector failureCollector = pipelineConfigurer.getStageConfigurer().getFailureCollector();
+    config.validate(failureCollector, inputSchema);
+    failureCollector.getOrThrowException();
+  }
 
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {

--- a/src/main/java/io/cdap/plugin/mfs/OutputFormat.java
+++ b/src/main/java/io/cdap/plugin/mfs/OutputFormat.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mfs;
+
+public enum OutputFormat implements EnumWithValue {
+  CSV("CSV"),
+  JSON( "JSON"),
+  GENERIC_RECORD("Generic Record");
+
+  private final String value;
+
+  OutputFormat(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return this.getValue();
+  }
+}

--- a/src/main/java/io/cdap/plugin/mfs/OutputType.java
+++ b/src/main/java/io/cdap/plugin/mfs/OutputType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mfs;
+
+public enum OutputType implements EnumWithValue {
+  AVRO("Avro"),
+  AVRO_ORC( "Avro ORC"),
+  AVRO_PARQUET("Avro Parquet"),
+  TEXT("Text"),
+  SEQUENCE_FILE("Sequence File");
+
+  private final String value;
+
+  OutputType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return this.getValue();
+  }
+}

--- a/src/main/java/io/cdap/plugin/mfs/writer/MultipleFileOutputProvider.java
+++ b/src/main/java/io/cdap/plugin/mfs/writer/MultipleFileOutputProvider.java
@@ -39,10 +39,10 @@ public class MultipleFileOutputProvider implements OutputFormatProvider {
 
     Map<String, String> arguments = context.getArguments().asMap();
     properties.put(OutputFormatDelegator.MFS_RUNTIME_ARGUMENTS, gson.toJson(arguments));
-    properties.put(OutputFormatDelegator.MFS_OUTPUT_TYPE, config.getType());
-    properties.put(OutputFormatDelegator.MFS_FILTER_TYPE, config.getFiltersType());
+    properties.put(OutputFormatDelegator.MFS_OUTPUT_TYPE, config.getType().toString());
+    properties.put(OutputFormatDelegator.MFS_FILTER_TYPE, config.getFiltersType().toString());
     properties.put(ExpressionFilter.EXPRESSION_CONFIG, config.getFiltersAsList()[partitionId]);
-    properties.put(OutputFormatDelegator.MFS_FORMATTER_TYPE, config.getFormat());
+    properties.put(OutputFormatDelegator.MFS_FORMATTER_TYPE, config.getFormat().toString());
     properties.put(DatasetProperties.SCHEMA, context.getInputSchema().toString());
     properties.put(OutputFormatDelegator.MFS_PARTITION_ID, String.valueOf(partitionId));
     properties.put(FileOutputFormat.OUTDIR, path);

--- a/src/test/java/io/cdap/plugin/mfs/MultipleFileSinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/mfs/MultipleFileSinkConfigTest.java
@@ -1,0 +1,129 @@
+package io.cdap.plugin.mfs;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.validation.CauseAttributes;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+public class MultipleFileSinkConfigTest {
+  private static final String MOCK_STAGE = "mockStage";
+  private static final Schema VALID_SCHEMA = Schema.recordOf(
+    "schema", Schema.Field.of("ID", Schema.nullableOf(Schema.of(Schema.Type.LONG))));
+
+  private static final MultipleFileConfig VALID_CONFIG = new MultipleFileConfig(
+      "myfile",
+        "/tmp/data",
+        "Text",
+        "CSV",
+        "ID > 0",
+        "Expression"
+  );
+
+  @Test
+  public void testValidConfig() {
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    VALID_CONFIG.validate(failureCollector, VALID_SCHEMA);
+    Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+  }
+
+  @Test
+  public void testInvalidOutputType() {
+    MultipleFileConfig config = MultipleFileConfig.builder(VALID_CONFIG)
+      .setType("nonExistentType")
+      .build();
+
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    config.validate(failureCollector, VALID_SCHEMA);
+    assertValidationFailed(failureCollector, MultipleFileConfig.PROPERTY_OUTPUT_TYPE);
+  }
+
+  @Test
+  public void testInvalidOutputFormat() {
+    MultipleFileConfig config = MultipleFileConfig.builder(VALID_CONFIG)
+      .setFormat("nonExistentFormat")
+      .build();
+
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    config.validate(failureCollector, VALID_SCHEMA);
+    assertValidationFailed(failureCollector, MultipleFileConfig.PROPERTY_OUTPUT_FORMAT);
+  }
+
+  @Test
+  public void testInvalidFiltersType() {
+    MultipleFileConfig config = MultipleFileConfig.builder(VALID_CONFIG)
+      .setFiltersType("nonExistentFiltersType")
+      .build();
+
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    config.validate(failureCollector, VALID_SCHEMA);
+    assertValidationFailed(failureCollector, MultipleFileConfig.PROPERTY_FILTERS_TYPE);
+  }
+
+  @Test
+  public void testNoFiltersForExpressionType() {
+    MultipleFileConfig config = MultipleFileConfig.builder(VALID_CONFIG)
+      .setFilters(null)
+      .build();
+
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    config.validate(failureCollector, VALID_SCHEMA);
+    assertValidationFailed(failureCollector, MultipleFileConfig.PROPERTY_FILTERS);
+  }
+
+  @Test
+  public void testHasFiltersForNoneType() {
+    MultipleFileConfig config = MultipleFileConfig.builder(VALID_CONFIG)
+      .setFiltersType("None")
+      .build();
+
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    config.validate(failureCollector, VALID_SCHEMA);
+    assertValidationFailed(failureCollector, MultipleFileConfig.PROPERTY_FILTERS);
+  }
+
+  @Test
+  public void testFilterExpressionInvalid() {
+    MultipleFileConfig config = MultipleFileConfig.builder(VALID_CONFIG)
+      .setFilters("x >> 0")
+      .build();
+
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    config.validate(failureCollector, VALID_SCHEMA);
+    assertValidationFailed(failureCollector, MultipleFileConfig.PROPERTY_FILTERS);
+  }
+
+  @Test
+  public void testFilterExpressionVariableNotFromSchema() {
+    MultipleFileConfig config = MultipleFileConfig.builder(VALID_CONFIG)
+      .setFilters("nonExistentField = 0")
+      .build();
+
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    config.validate(failureCollector, VALID_SCHEMA);
+    assertValidationFailed(failureCollector, MultipleFileConfig.PROPERTY_FILTERS);
+  }
+
+  private static void assertValidationFailed(MockFailureCollector failureCollector, String paramName) {
+    List<ValidationFailure> failureList = failureCollector.getValidationFailures();
+    Assert.assertEquals(1, failureList.size());
+    ValidationFailure failure = failureList.get(0);
+    List<ValidationFailure.Cause> causeList = getCauses(failure, CauseAttributes.STAGE_CONFIG);
+    Assert.assertEquals(1, causeList.size());
+    ValidationFailure.Cause cause = causeList.get(0);
+    Assert.assertEquals(paramName, cause.getAttribute(CauseAttributes.STAGE_CONFIG));
+  }
+
+  @Nonnull
+  private static List<ValidationFailure.Cause> getCauses(ValidationFailure failure, String stacktrace) {
+    return failure.getCauses()
+      .stream()
+      .filter(cause -> cause.getAttribute(stacktrace) != null)
+      .collect(Collectors.toList());
+  }
+}

--- a/widgets/MultipleFileSink-batchsink.json
+++ b/widgets/MultipleFileSink-batchsink.json
@@ -43,7 +43,7 @@
           "name": "format",
           "widget-attributes" : {
             "default" : "CSV",
-            "values" : [ "CSV", "JSON"]
+            "values" : [ "CSV", "JSON", "Generic Record"]
           }
         },
         {
@@ -63,12 +63,11 @@
         {
           "widget-type": "select",
           "label": "Assignment type",
-          "name": "filters-type",
+          "name": "filtersType",
           "widget-attributes": {
             "default": "None",
             "values": [
               "Expression",
-              "Schema",
               "None"
             ]
           }


### PR DESCRIPTION
1. Fixed a couple of errors which were present in widget file. Like using enum values different from the actual used in code and wrong variable name.
2. When corrective reason is obvious I have not added it (which is in most cases here).
3. I didn't add stack trace for cases when it's obvious what went from (as advised by Albert).